### PR TITLE
Requiring the top-level library file should load the serializer and deserializer

### DIFF
--- a/lib/simple_serializer.rb
+++ b/lib/simple_serializer.rb
@@ -1,4 +1,7 @@
 require 'simple_serializer/version'
 
+require 'simple_serializer/serializer'
+require 'simple_serializer/deserializer'
+
 module SimpleSerializer
 end

--- a/lib/simple_serializer/deserializer.rb
+++ b/lib/simple_serializer/deserializer.rb
@@ -21,49 +21,49 @@
 #    SomeDeserializer.deserialize_array([object1, object2, ...], [data1, data2, ...])
 #
 module SimpleSerializer
-class Deserializer
-  class << self
-    attr_accessor :_object_attributes
+  class Deserializer
+    class << self
+      attr_accessor :_object_attributes
 
-    def inherited(base)
-      base._object_attributes = []
-    end
+      def inherited(base)
+        base._object_attributes = []
+      end
 
-    def object_attributes(*attrs)
-      @_object_attributes.concat attrs
+      def object_attributes(*attrs)
+        @_object_attributes.concat attrs
 
-      attrs.each do |attr|
-        define_method attr do
-          @data[attr]
-        end unless method_defined?(attr)
+        attrs.each do |attr|
+          define_method attr do
+            @data[attr]
+          end unless method_defined?(attr)
 
-        define_method "set_#{attr}" do
-          object.send("#{attr}=", send(attr)) if @data.has_key?(attr)
-        end unless method_defined?("set_#{attr}")
+          define_method "set_#{attr}" do
+            object.send("#{attr}=", send(attr)) if @data.has_key?(attr)
+          end unless method_defined?("set_#{attr}")
+        end
+      end
+
+      def deserialize_array(objects, data)
+        objects.zip(data).map { |obj, datum| deserialize(obj, datum) }
+      end
+
+      def deserialize(object, data)
+        self.new(object, data).deserialize
       end
     end
 
-    def deserialize_array(objects, data)
-      objects.zip(data).map { |obj, datum| deserialize(obj, datum) }
+    attr_reader :object, :data
+
+    def initialize(object, data)
+      @object = object
+      @data = data
     end
 
-    def deserialize(object, data)
-      self.new(object, data).deserialize
+    def deserialize
+      self.class._object_attributes.dup.each do |name|
+        send("set_#{name}")
+      end
+      object
     end
   end
-
-  attr_reader :object, :data
-
-  def initialize(object, data)
-    @object = object
-    @data = data
-  end
-
-  def deserialize
-    self.class._object_attributes.dup.each do |name|
-      send("set_#{name}")
-    end
-    object
-  end
-end
 end

--- a/spec/unit/simple_serializer/deserializer_spec.rb
+++ b/spec/unit/simple_serializer/deserializer_spec.rb
@@ -1,5 +1,5 @@
 require 'unit_spec_helper'
-require 'simple_serializer/deserializer'
+require 'simple_serializer'
 
 describe SimpleSerializer::Deserializer do
 

--- a/spec/unit/simple_serializer/serializer_spec.rb
+++ b/spec/unit/simple_serializer/serializer_spec.rb
@@ -1,5 +1,5 @@
 require 'unit_spec_helper'
-require 'simple_serializer/serializer'
+require 'simple_serializer'
 
 describe SimpleSerializer::Serializer do
 


### PR DESCRIPTION
## Current behaviour

`require "simple_serializer"` does nothing.
- `SimpleSerializer::Serializer` is undefined.
- `SimpleSerializer::Deserializer` is undefined.
## Desired behaviour

`require "simple_serializer"` makes the following available:
- SimpleSerializer::Serializer
- SimpleSerializer::Deserializer

If you want only one of them specifically, you can still do:

`require "simple_serializer/serializer"`
## Extras

I've also updated some indentation `deserializer.rb` in f69f324, to make it consistent with `serializer.rb` 
